### PR TITLE
fix: gracefully handle health router service failures

### DIFF
--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -21,8 +21,17 @@ _llm_service = EnhancedLLMService()
 
 def _collect_service_status():
     """Gather status for core services."""
-    db_health = db_manager.health_check()
-    config_health = config_service.health_check()
+    try:
+        db_health = db_manager.health_check()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.error(f"Database health check failed: {e}")
+        db_health = {"status": "unhealthy", "error": str(e)}
+
+    try:
+        config_health = config_service.health_check()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.error(f"Config health check failed: {e}")
+        config_health = {"status": "unhealthy", "error": str(e)}
 
     try:
         llm_health = _llm_service.validate_configuration()


### PR DESCRIPTION
## Summary
- guard database and configuration health checks with try/except
- preserve structured 503 responses when underlying services fail

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b85ca5e54083299dc85eb7c0248872